### PR TITLE
adds webphenote-config/ for GOLR loading. updates README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,25 @@ WebPhenote, aka PhenoTua is a Monarch adaptation of [Noctua](http://noctua.berke
 
 The current instance can be used at http://create.monarchinitiative.org/
 
-We envision PhenoTua as a series of domain-specific widgets and custom forms layered on top of the generic Noctua framework - similar to Plugins for Protege. The exact nature of the architecture and coupling of the projects is evolving.
+We envision WebPhenote as a series of domain-specific widgets and custom forms layered on top of the generic Noctua framework - similar to Plugins for Protege. The exact nature of the architecture and coupling of the projects is evolving.
 
-Currently this repo only contains ultra-minimal files for making a mini test instance of noctua, but with phenotypes. Some of the code was developed in the main noctua repo on https://github.com/geneontology/noctua for convenience.
+Currently this repo only contains ultra-minimal files for making a mini test instance of Noctua, but with phenotypes. Some of the code was developed in the main Noctua repo on [https://github.com/geneontology/noctua](https://github.com/geneontology/noctua) for convenience.
 
-In the future this repo may go away and be subsumed into a plugins/contrib repo for noctua.
+In the future this repo may go away and be subsumed into a plugins/contrib repo for Noctua.
 
 In the interim, the issue tracker should still be useful.
 
-## Technical Details
+## User Interface Details
 
-The interface is best understood in terms of layers: the base system which is a generic graph editing system,
-and on top of that are various high-level views, widgets, renderers or forms that abstract away from this lower-level representation.
-For example, the *disease-phenotype* form is currently [accessible from the FORM button here](http://create.monarchinitiative.org/).
-This presents fields such as "disease" and "phenotype" and "onset" with implicit relationships between them.
+The user interface is best understood in terms of layers:
 
-The underlying datamodel for PhenoTua is an OWL Abox - i.e. a set of individuals and assertions about those individuals. The individuals can be typed by any class or class expression, typically coming from monarch.owl
+- The base layer which is a generic graph editing system that can create, edit and save graphs (OWL models, typically).
+-  Views, widgets, renderers and forms that provide convenient and domain-focused tools that build upon the underlying graph editing system.
+
+For example, the *Disease-Phenotype* form is currently [accessible from the FORM button here](http://create.monarchinitiative.org/).
+This form presents fields such as "disease" and "phenotype" and "onset" with implicit relationships between them. This allows for easier creation and curation of this common type of relationship, while still generating the same format of models viewable in the graph editor.
+
+The underlying data model for WebPhenote is an OWL Abox - i.e. a set of individuals and assertions about those individuals. The individuals can be typed by any class or class expression, typically coming from `monarch.owl`.
 
 An example of a simple OWL assertion would be:
 
@@ -52,14 +55,20 @@ In the "exploded" view each distinct individual is shown as a box:
     
 In both cases, only OWL individuals are shown.
 
-The graph UI can be considered the "base metal" layer of the Noctua system, akin to the individual view in Protege. It is possible to say anything possible within the RO and monarch vocabularies here (provided the reasoner does not deem this inconsistent).
+The graph UI can be considered the "base metal" layer of the Noctua system, akin to the individual view in Protege. It is possible to say anything possible within the RO and Monarch vocabularies here (provided the reasoner does not deem this inconsistent).
 
 For most users this is too low level. WebPhenote will consist of forms and widgets that are "convenience layers" on top of this base system.
 
-For instance the disease-phenotype form here:
-http://poole.monarchinitiative.org:8910/basic/gomodel:55bbb58200000001
+For instance the disease-phenotype form here (this link may break periodically as we improve our WebPhenote example models):
 
-is intended to emulate a simple phenote configuration. The underlying model is still OWL individuals
+[http://create.monarchinitiative.org/basic/gomodel:56d4f20300000033](http://create.monarchinitiative.org/basic/gomodel:56d4f20300000033)
+
+is intended to emulate a simple phenote configuration describing the association of Parkinson's Disease with Vocal Tremor and Adult Onset. The underlying model is still OWL individuals and can be viewed via the graph editor here [http://create.monarchinitiative.org/editor/graph/gomodel:56d4f20300000033](http://create.monarchinitiative.org/editor/graph/gomodel:56d4f20300000033)
+
+
+
+
+
 
 
     

--- a/webphenote-config/.gitignore
+++ b/webphenote-config/.gitignore
@@ -1,0 +1,1 @@
+cached-models/

--- a/webphenote-config/checkMirror.sh
+++ b/webphenote-config/checkMirror.sh
@@ -1,0 +1,28 @@
+# See: https://github.com/owlcollab/owltools/wiki/Import-Chain-Mirroring
+
+export CACHEDIR=`pwd`/cached-models
+export CATALOG=./catalog.xml
+#export OWLTOOLS_JAR="../java/lib/owltools-runner-all.jar"
+export OWLTOOLS_JAR="../../owltools/OWLTools-Runner/bin/owltools-runner-all.jar"
+export OWLTOOLS="java -Xms3000m -Xmx5500m -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar ${OWLTOOLS_JAR}"
+
+# export ROOT=http://purl.obolibrary.org/obo/upheno/monarch.owl
+export ROOT=http://purl.obolibrary.org/obo/so.owl
+
+$OWLTOOLS \
+	--catalog-xml $CACHEDIR/$CATALOG \
+	$ROOT \
+	> $CACHEDIR/check.log
+
+
+grep 'from: http:' $CACHEDIR/check.log > $CACHEDIR/uncached.log
+
+echo ""
+echo "# Uncached entries"
+cat $CACHEDIR/uncached.log
+echo ""
+echo ""
+echo ""
+echo ""
+echo "# Complete log"
+cat $CACHEDIR/check.log

--- a/webphenote-config/mirrorOntologyLocally.sh
+++ b/webphenote-config/mirrorOntologyLocally.sh
@@ -1,0 +1,23 @@
+# See: https://github.com/owlcollab/owltools/wiki/Import-Chain-Mirroring
+
+export CACHEDIR=`pwd`/cached-models
+export CATALOG=./catalog.xml
+#export OWLTOOLS_JAR="../java/lib/owltools-runner-all.jar"
+export OWLTOOLS_JAR="../../owltools/OWLTools-Runner/bin/owltools-runner-all.jar"
+export OWLTOOLS="java -Xms3000m -Xmx5500m -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar ${OWLTOOLS_JAR}"
+
+# export ROOT=http://purl.obolibrary.org/obo/upheno/monarch.owl
+export ROOT=http://purl.obolibrary.org/obo/so.owl
+
+mkdir -p $CACHEDIR
+
+$OWLTOOLS \
+	$ROOT \
+	--slurp-import-closure \
+	-d $CACHEDIR \
+	-c $CATALOG \
+	> $CACHEDIR/mirror.log
+
+echo ""
+echo ""
+cat $CACHEDIR/mirror.log

--- a/webphenote-config/ont-config.yaml
+++ b/webphenote-config/ont-config.yaml
@@ -1,0 +1,239 @@
+####
+#### The ontology description file for GOlr and AmiGO.
+####
+id: ontology
+schema_generating: true
+description: Gene Ontology Term, Synonym, or Definition.
+display_name: Ontology
+document_category: ontology_class
+weight: 40
+boost_weights: annotation_class^3.0 annotation_class_label^5.5 description^1.0 comment^0.5 synonym^1.0 alternate_id^1.0 regulates_closure^1.0 regulates_closure_label^1.0
+result_weights: annotation_class^8.0 description^6.0 source^4.0 synonym^3.0 alternate_id^2.0
+filter_weights: source^4.0 subset^3.0 regulates_closure_label^1.0 is_obsolete^0.0
+fields:
+  - id: id
+    description: Term identifier.
+    display_name: Acc
+    type: string
+    property: [getIdentifier]
+  - id: annotation_class
+    description: Term identifier.
+    display_name: Term
+    type: string
+    property: [getIdentifier]
+  - id: annotation_class_label
+    description: Identifier.
+    display_name: Term
+    type: string
+    property: [getLabel]
+    searchable: true
+## Ever used with terms?
+# - id: descriptive_name
+#     description: Term description.
+#     display_name: Description
+#     type: string
+#     property: [descriptive_name]
+#    searchable: true
+  - id: description
+    description: "Term definition."
+    display_name: Definition
+    type: string
+    property: [getDef]
+    searchable: true
+  - id: source
+    description: "Term namespace."
+    display_name: Ontology source
+    type: string
+    property: [getNamespace]
+  - id: is_obsolete
+    description: Is the term obsolete?
+    display_name: Obsoletion
+    type: boolean
+    property: [getIsObsoleteBinaryString]
+  - id: comment
+    description: Term comments.
+    display_name: Comments
+    type: string
+    property: [getComments]
+    cardinality: multi
+    searchable: true
+  - id: synonym
+    description: Term synonyms.
+    display_name: Synonyms
+    type: string
+    property: [getOBOSynonymStrings]
+    cardinality: multi
+    searchable: true
+  - id: alternate_id
+    description: Alternate term identifier.
+    display_name: Alt ID
+    type: string
+    property: [getAnnotationPropertyValues, alt_id]
+    cardinality: multi
+  - id: replaced_by
+    description: Term that replaces this term.
+    display_name: Replaced By
+    type: string
+    property: [getAnnotationPropertyValues, replaced_by]
+    cardinality: multi
+  - id: consider
+    description: Others terms you might want to look at.
+    display_name: Consider
+    type: string
+    property: [getAnnotationPropertyValues, consider]
+    cardinality: multi
+  - id: subset
+    description: "Special use collections of terms."
+    display_name: Subset
+    type: string
+    property: [getSubsets]
+    cardinality: multi
+  - id: definition_xref
+    description: Definition cross-reference.
+    display_name: Def xref
+    type: string
+    property: [getDefXref]
+    cardinality: multi
+  - id: database_xref
+    description: Database cross-reference.
+    display_name: DB xref
+    type: string
+    property: [getXref]
+    cardinality: multi
+  - id: isa_partof_closure
+    description: "Ancestral terms (is_a/part_of)."
+    display_name: Is-a/part-of
+    type: string
+    cardinality: multi
+    property:
+      - "getRelationIDClosure"
+      - "BFO:0000050"
+  - id: isa_partof_closure_label
+    description: "Ancestral terms (is_a/part_of)."
+    display_name: Is-a/part-of
+    type: string
+    cardinality: multi
+    property:
+      - "getRelationLabelClosure"
+      - "BFO:0000050"
+    searchable: true
+  - id: regulates_closure
+    description: "Ancestral terms (regulates, occurs in, capable_of)."
+    display_name: Ancestor
+    type: string
+    cardinality: multi
+    property:
+      - "getRelationIDClosure"
+      - "BFO:0000050"
+      - "BFO:0000066"
+      - "RO:0002211"
+      - "RO:0002212"
+      - "RO:0002213"
+      - "RO:0002215"
+      - "RO:0002216"
+  - id: regulates_closure_label
+    description: "Ancestral terms (regulates, occurs in, capable_of)."
+    display_name: Ancestor
+    type: string
+    cardinality: multi
+    property:
+      - "getRelationLabelClosure"
+      - "BFO:0000050"
+      - "BFO:0000066"
+      - "RO:0002211"
+      - "RO:0002212"
+      - "RO:0002213"
+      - "RO:0002215"
+      - "RO:0002216"
+    searchable: true
+  - id: topology_graph_json
+    description: "JSON blob form of the local stepwise topology graph. Uses various relations (including regulates, occurs in, capable_of)."
+    display_name: Topology graph (JSON)
+    type: string
+    property:
+      - "getSegmentShuntGraphJSON"
+      - "BFO:0000050"
+      - "BFO:0000066"
+      - "RO:0002211"
+      - "RO:0002212"
+      - "RO:0002213"
+      - "RO:0002215"
+      - "RO:0002216"
+    indexed: false
+  - id: regulates_transitivity_graph_json
+    description: "JSON blob form of the local relation transitivity graph. Uses various relations (including regulates, occurs in, capable_of)."
+    display_name: Regulates transitivity graph (JSON)
+    type: string
+    property:
+      - "getLineageShuntGraphJSON"
+      - "BFO:0000050"
+      - "BFO:0000066"
+      - "RO:0002211"
+      - "RO:0002212"
+      - "RO:0002213"
+      - "RO:0002215"
+      - "RO:0002216"
+    indexed: false
+  ## TODO/BUG: These are currently populated by junk functions.
+  ## https://github.com/geneontology/amigo/issues/56
+  - id: only_in_taxon
+    description: "Only in taxon."
+    display_name: Only in taxon
+    type: string
+    property: [getDummyString]
+    searchable: true
+  - id: only_in_taxon_label
+    description: "Only in taxon label."
+    display_name: Only in taxon
+    type: string
+    property: [getDummyString]
+    searchable: true
+  - id: only_in_taxon_closure
+    description: "Only in taxon closure."
+    display_name: Only in taxon (IDs)
+    type: string
+    cardinality: multi
+    property: [getDummyStrings]
+  - id: only_in_taxon_closure_label
+    description: "Only in taxon label closure."
+    display_name: Only in taxon
+    type: string
+    cardinality: multi
+    property: [getDummyStrings]
+    searchable: true
+  ## TODO/BUG: These are currently populated by junk functions.
+  ## Next items are defined in https://github.com/geneontology/amigo/issues/249
+  - id: annotation_extension_owl_json
+    description: "A non-lossy representation of conjunctions and disjunctions in c16 (JSON)."
+    display_name: Annotation extension
+    type: string
+    property: [getDummyString]
+  - id: annotation_relation
+    description: "This is equivalent to the relation field in GPAD."
+    display_name: Annotation relation
+    type: string
+    property: [getDummyString]
+  - id: annotation_relation_label
+    description: "This is equivalent to the relation field in GPAD."
+    display_name: Annotation relation
+    type: string
+    property: [getDummyString]
+    searchable: true
+  - id: equivalent_class_expressions_json
+    description: "For any class document C, this will contain json(CE) for all axioms of form EquivalentClasses(C ... CE ....)."
+    display_name: Eq class expressions
+    type: string
+    property: [getDummyString]
+  - id: disjoint_class_list
+    description: "Disjoint classes."
+    display_name: Disjoint classes
+    type: string
+    cardinality: multi
+    property: [getDummyStrings]
+  - id: disjoint_class_list_label
+    description: "Disjoint classes."
+    display_name: Disjoint classes
+    type: string
+    cardinality: multi
+    searchable: true
+    property: [getDummyStrings]

--- a/webphenote-config/uploadMonarchToOntologyCore.sh
+++ b/webphenote-config/uploadMonarchToOntologyCore.sh
@@ -1,0 +1,47 @@
+# Load ontology into a GOLR core named /ontology
+# This script intended to run on the GOLR server itself, for efficiency and
+# to avoid tying up a laptop for hours.
+#
+# This script assumes you have a mirrored ontology with a catalog.xml
+# Use the mirrorOntologyLocally.sh script to prepare this cache.
+#
+
+#export OWLTOOLS_JAR="../java/lib/owltools-runner-all.jar"
+export OWLTOOLS_JAR="../../owltools/OWLTools-Runner/bin/owltools-runner-all.jar"
+export OWLTOOLS="java -Xms5500m -Xmx20500m -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar ${OWLTOOLS_JAR}"
+
+export CACHEDIR=`pwd`/cached-models
+export CATALOG=$CACHEDIR/catalog.xml
+
+#export SOLR_URL=http://solr-dev.monarchinitiative.org/solr/ontology/
+export SOLR_URL=http://localhost/solr/ontology/   # because we are running on GOLR server
+
+export SOLR_CONFIG=ont-config.yaml
+
+export ONTOLOGY_ROOT=http://purl.obolibrary.org/obo/ro.owl
+# export ONTOLOGY_ROOT=http://purl.obolibrary.org/obo/upheno/monarch.owl
+
+# Purge anything in the core
+
+$OWLTOOLS \
+       --solr-log solr-purge.log \
+       --solr-url $SOLR_URL \
+       --solr-purge \
+       --solr-config $SOLR_CONFIG
+
+# Load from the mirrored ontology, into the GOLR core
+
+$OWLTOOLS \
+	--catalog-xml $CATALOG \
+	$ONTOLOGY_ROOT \
+	--merge-support-ontologies \
+	--remove-subset-entities upperlevel \
+	--merge-imports-closure \
+	--remove-disjoints \
+	--reasoner elk \
+	--silence-elk \
+	--solr-log solr-load.log \
+	--solr-url $SOLR_URL \
+	--solr-config $SOLR_CONFIG \
+	--solr-load-ontology \
+	--solr-load-ontology-general


### PR DESCRIPTION
- dds webphenote-config/ which knows how to get the monarch ontology and load it into a golr core. 
- Minor updates to README.md.
- Adds a .gitignore to webphenote-config so no one erroneously commits the mirrored cache files.
