### PR TITLE
Users.yaml updates. Generalize mirror/upload scripts for multiple ontologies

### DIFF
--- a/webphenote-config/checkMirror.sh
+++ b/webphenote-config/checkMirror.sh
@@ -1,28 +1,42 @@
 # See: https://github.com/owlcollab/owltools/wiki/Import-Chain-Mirroring
 
-export CACHEDIR=`pwd`/cached-models
-export CATALOG=./catalog.xml
+# ./checkMirror.sh [ro|monarch|hp] # Default is ro
 
+ROOTOWL="${1:-ro}"
+if [ "$ROOTOWL" == 'hp' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/hp.owl'
+fi
+if [ "$ROOTOWL" == 'monarch' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/upheno/monarch.owl'
+fi
+if [ "$ROOTOWL" == 'ro' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/ro.owl'
+fi
+echo "ROOTOWL: $ROOTOWL"
+echo "CACHEDIR: $CACHEDIR"
+echo "ROOTOWL: $ROOTOWL"
+echo "ROOTOWL_URL: $ROOTOWL_URL"
+
+export CACHEDIR=`pwd`/$ROOTOWL-cached/
+export CATALOG=./catalog.xml
 export OWLTOOLS_JAR="/opt/owltools/OWLTools-Runner/bin/owltools-runner-all.jar"
 export OWLTOOLS="java -Xms3000m -Xmx5500m -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar ${OWLTOOLS_JAR}"
 
-# export ROOT=http://purl.obolibrary.org/obo/upheno/monarch.owl
-export ROOT=http://purl.obolibrary.org/obo/so.owl
-
 $OWLTOOLS \
 	--catalog-xml $CACHEDIR/$CATALOG \
-	$ROOT \
+	$ROOTOWL_URL \
 	> $CACHEDIR/check.log
-
 
 grep 'from: http:' $CACHEDIR/check.log > $CACHEDIR/uncached.log
 
+echo ""
+echo "# Complete log"
+cat $CACHEDIR/check.log
+echo ""
+echo ""
 echo ""
 echo "# Uncached entries"
 cat $CACHEDIR/uncached.log
 echo ""
 echo ""
 echo ""
-echo ""
-echo "# Complete log"
-cat $CACHEDIR/check.log

--- a/webphenote-config/groups.yaml
+++ b/webphenote-config/groups.yaml
@@ -1,0 +1,22 @@
+####
+#### Metadata on Monarch groups, derived from GOC groups
+#### See https://github.com/geneontology/go-site/tree/master/metadata
+####
+-
+  label: 'Monarch'
+  id: https://monarchinitiative.org
+-
+  label: 'LBL'
+  id: http://lbl.gov
+-
+  label: 'GO Central'
+  id: http://geneontology.org
+-
+  label: 'Planteome'
+  id: http://planteome.org
+-
+  label: 'Berkeley BOP'
+  id: http://berkeleybop.org
+-
+  label: 'ZFIN'
+  id: http://zfin.org

--- a/webphenote-config/mirrorOntologyLocally.sh
+++ b/webphenote-config/mirrorOntologyLocally.sh
@@ -1,17 +1,36 @@
 # See: https://github.com/owlcollab/owltools/wiki/Import-Chain-Mirroring
 
-export CACHEDIR=`pwd`/cached-models
+# ./mirrorOntologyLocally.sh [ro|monarch|hp] # Default is ro
+
+ROOTOWL="${1:-ro}"
+if [ "$ROOTOWL" == 'hp' ]; then
+	# ROOTOWL_URL='http://purl.obolibrary.org/obo/hp.owl'
+	ROOTOWL_URL='./hp.owl'
+fi
+if [ "$ROOTOWL" == 'monarch' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/upheno/monarch.owl'
+fi
+if [ "$ROOTOWL" == 'go' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/go/extensions/go-lego.owl'
+fi
+if [ "$ROOTOWL" == 'ro' ]; then
+	ROOTOWL_URL='http://purl.obolibrary.org/obo/ro.owl'
+fi
+
+echo "# ROOTOWL: $ROOTOWL"
+echo "# CACHEDIR: $CACHEDIR"
+echo "# ROOTOWL: $ROOTOWL"
+echo "# ROOTOWL_URL: $ROOTOWL_URL"
+
+export CACHEDIR=`pwd`/$ROOTOWL-cached/
 export CATALOG=./catalog.xml
 export OWLTOOLS_JAR="/opt/owltools/OWLTools-Runner/bin/owltools-runner-all.jar"
 export OWLTOOLS="java -Xms3000m -Xmx5500m -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar ${OWLTOOLS_JAR}"
 
-# export ROOT=http://purl.obolibrary.org/obo/upheno/monarch.owl
-export ROOT=http://purl.obolibrary.org/obo/so.owl
-
 mkdir -p $CACHEDIR
 
 $OWLTOOLS \
-	$ROOT \
+	$ROOTOWL_URL \
 	--slurp-import-closure \
 	-d $CACHEDIR \
 	-c $CATALOG \

--- a/webphenote-config/users.yaml
+++ b/webphenote-config/users.yaml
@@ -1,9 +1,39 @@
 -
+  nickname: 'Matthew Brush'
+  email-md5:
+    - 693f54b57c5b0fd811daaa764f0a408a
+  authorizations:
+    noctua-go:
+      allow-edit: true
+  uri: 'http://orcid.org/0000-0002-1048-5019'
+  organization: OHSU
+  xref: 'OHSUMI:mb'
+-
+  nickname: 'Jim Balhoff'
+  email-md5:
+    - f28e1be9fc622bffbecb166378ef2456
+  authorizations:
+    noctua-go:
+      allow-edit: true
+  uri: 'http://orcid.org/0000-0002-8688-6599'
+  organization: OHSU
+  xref: 'NESCMI:jpb'
+-
+  nickname: 'Erin Foster'
+  email-md5:
+    - 6c1b87e090990c775e3127eb15d0114f
+  authorizations:
+    noctua-go:
+      allow-edit: true
+  uri: 'http://orcid.org/0000-0001-6908-9849'
+  organization: OHSU
+  xref: 'OHSUMI:ef'
+-
   nickname: 'Dan Keith'
   email-md5:
     - 1da7b1538b4b21f1cfe7ce462965a549
   authorizations:
-    noctua-monarch:
+    noctua-go:
       allow-edit: true
   uri: 'http://orcid.org/0000-0002-1643-6242'
   organization: OHSU
@@ -13,7 +43,7 @@
   email-md5:
     - 2c3e08f58b80ed58f692a238af40d3d6
   authorizations:
-    noctua-monarch:
+    noctua-go:
       allow-edit: true
   uri: 'http://orcid.org/0000-0002-9353-5498'
   organization: OHSU
@@ -403,8 +433,8 @@
     - 17d2b31399e746373f3b18f7f65ab7fe
   organization: OHSU
   authorizations:
-    termgenie-go:
-      allow-write: true
+    noctua-go:
+      allow-edit: true
 -
   uri: 'http://orcid.org/0000-0003-3212-6364'
   xref: 'GOC:ha'
@@ -2219,7 +2249,7 @@
   uri: 'GOC:pnr'
   xref: 'GOC:pnr'
   email-md5:
-    - c727817e3b98721cf962f69613afd192
+    - 7e344a83c11dec211b5be2e312bf16f4
   authorizations:
     noctua-go:
       allow-edit: true


### PR DESCRIPTION
- Improves the mirroring scripts to more easily use different ontology roots
- Updates users.yaml to add Jim and Erin
- Updates Peter Robinson in users.yaml
- adds Matthew Brush to users.yaml
- updates the mirroring scripts that  build the cached OWL files
- adds GO option to mirrorOntologyLocally.sh
- Adds groups.yaml
- Improve uploadMonarchToOntologyCore.sh to use the correct cache and
  catalog, based upon the parameter: go/monarch/hpo